### PR TITLE
fix: reduce cache revalidation time from 1 hour to 1 minute

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,7 +5,7 @@ import { fetchGithubIssues } from "@/lib/github"
 import { GitHubLogoIcon } from "@radix-ui/react-icons"
 import { Suspense } from "react"
 
-export const revalidate = 3600 // Revalidate every hour
+export const revalidate = 60 // Revalidate every minute for fresher bounty data
 
 export default async function Home() {
   const issues = await fetchGithubIssues(process.env.GITHUB_TOKEN || "")

--- a/components/IssueRoulette.tsx
+++ b/components/IssueRoulette.tsx
@@ -9,7 +9,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import type { IssuesByFilter, Issue } from "@/lib/github"
+import type { Issue, IssuesByFilter } from "@/lib/github"
 import { format } from "date-fns"
 import { AlertCircle, Calendar, Dices, ExternalLink, User } from "lucide-react"
 import { useState } from "react"
@@ -32,8 +32,9 @@ export default function IssueRoulette({
 
     try {
       // Filter available issues based on bounty preference and used status
-      const availableIssues = initialIssues[filterType]
-        .filter((issue) => !usedIssues.has(issue.id))
+      const availableIssues = initialIssues[filterType].filter(
+        (issue) => !usedIssues.has(issue.id),
+      )
 
       if (availableIssues.length === 0) {
         setUsedIssues(new Set())

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -32,7 +32,7 @@ export async function fetchGithubIssues(
     org,
   })
 
-  const reposNotArchived = repos.filter(repo => !repo.archived)
+  const reposNotArchived = repos.filter((repo) => !repo.archived)
 
   // Fetch issues from all repositories; tolerate per-repo fetch failures
   const allIssues = await Promise.allSettled(
@@ -52,10 +52,7 @@ export async function fetchGithubIssues(
           },
         }))
       } catch (error) {
-        console.error(
-          `Failed to fetch issues for ${org}/${repo.name}:`,
-          error,
-        )
+        console.error(`Failed to fetch issues for ${org}/${repo.name}:`, error)
         return []
       }
     }),
@@ -133,9 +130,9 @@ export async function fetchGithubIssues(
   }
 
   return {
-    "bounty": getBountiedIssues(),
-    "all": getWeightedIssues(),
-    "unbountied": processedIssues
+    bounty: getBountiedIssues(),
+    all: getWeightedIssues(),
+    unbountied: processedIssues
       .filter((issue) => (issue.bountyAmount ?? 0) === 0)
       .slice(0, 20), // Keep same limit as other filters
   }


### PR DESCRIPTION
## Summary
Fixes #10

The previous 1-hour cache was causing bounty data to appear stale. This PR reduces the Next.js ISR (Incremental Static Regeneration) revalidation time from 3600 seconds (1 hour) to 60 seconds (1 minute).

### Changes:
- Updated `revalidate` constant in `app/page.tsx` from 3600 to 60 seconds
- Applied minor formatting fixes from biome check

### Benefits:
- Users will see much fresher bounty information
- New issues and bounty updates appear within 1 minute instead of 1 hour
- Still maintains reasonable API rate limits (revalidates only once per minute max)

/claim #10